### PR TITLE
Represent lua:nil as racket:null

### DIFF
--- a/lua-lib/private/nil.rkt
+++ b/lua-lib/private/nil.rkt
@@ -10,8 +10,7 @@
  falsy?
  truthy?)
 
-(define nil
-  (string->uninterned-symbol "nil"))
+(define nil null)
 
 (define (nil? v)
   (eq? nil v))


### PR DESCRIPTION
I'm not sure if this breaks something, but IIUC the current implementation is not using `racket:null` for something else.

Now `lua:nil` is represented as a racket uninterned symbol. The advantage of `racket:null` is that it can be constant propagated and constant folded by the compiler, and perhaps other optimizations.

Note that the docs about using lua from racket should be updated.

--

Another possibility is to use `racket:void` instead of `racket:null`. I though about that for a short time, and choose `racket:null` because it feels more natural. Also, when using lua from racket, the result of some functions is `racket:void` so it may be confusing. Anyway, I'm not sure it's the best choice.
